### PR TITLE
유저 찾기 서비스 분리[#back-20]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/user/Service/UserFinder.java
+++ b/src/main/java/com/sesac7/hellopet/domain/user/Service/UserFinder.java
@@ -1,0 +1,7 @@
+package com.sesac7.hellopet.domain.user.Service;
+
+import com.sesac7.hellopet.domain.user.entity.User;
+
+public interface UserFinder {
+    User findUserByUsername(String email);
+}

--- a/src/main/java/com/sesac7/hellopet/domain/user/Service/UserFinderImpl.java
+++ b/src/main/java/com/sesac7/hellopet/domain/user/Service/UserFinderImpl.java
@@ -1,0 +1,21 @@
+package com.sesac7.hellopet.domain.user.Service;
+
+import com.sesac7.hellopet.domain.user.entity.User;
+import com.sesac7.hellopet.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+@RequiredArgsConstructor
+public class UserFinderImpl implements UserFinder {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User findUserByUsername(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "등록된 유저가 없습니다."));
+    }
+}

--- a/src/main/java/com/sesac7/hellopet/domain/user/Service/UserService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/user/Service/UserService.java
@@ -11,7 +11,7 @@ import com.sesac7.hellopet.domain.user.entity.User;
 import com.sesac7.hellopet.domain.user.entity.UserDetail;
 import com.sesac7.hellopet.domain.user.repository.UserDetailRepository;
 import com.sesac7.hellopet.domain.user.repository.UserRepository;
-import jakarta.persistence.EntityExistsException;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.regex.Pattern;
 
 @Service
 @Transactional
@@ -53,7 +51,8 @@ public class UserService {
                 ? request.getUserProfileUrl()
                 : "https://i.namu.wiki/i/M0j6sykCciGaZJ8yW0CMumUigNAFS8Z-dJA9h_GKYSmqqYSQyqJq8D8xSg3qAz2htlsPQfyHZZMmAbPV-Ml9UA.webp";
 
-        if(doCheck(CheckField.EMAIL, request.getEmail()) && doCheck(CheckField.NICKNAME, request.getNickname()) && doCheck(CheckField.PHONE, request.getPhoneNumber())) {
+        if (doCheck(CheckField.EMAIL, request.getEmail()) && doCheck(CheckField.NICKNAME, request.getNickname())
+                && doCheck(CheckField.PHONE, request.getPhoneNumber())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용중입니다");
         }
 
@@ -134,6 +133,7 @@ public class UserService {
 
         return false;
     }
+
     public UserDetailResponse getUserDetail(CustomUserDetails userDetails) {
         User user = getUserByUsername(userDetails.getUsername());
         UserDetail userDetail = user.getUserDetail();
@@ -145,7 +145,9 @@ public class UserService {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "not found user"));
     }
+
     public User findUser(String username) {
-        return userRepository.findByEmail(username).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "등록된 유저가 없습니다."));
+        return userRepository.findByEmail(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "등록된 유저가 없습니다."));
     }
 }


### PR DESCRIPTION
현재 도메인마다 유저를 사용할때 유저가 인증을 거쳤다고 해도 유저를 DB 에서 가져오고 있습니다. 찾는 서비스만 분리하여 고도화 하면 좋을 것 같습니다