### PR TITLE
입양 신청서 승인/거절 기능 구현 [#back-44]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
@@ -2,16 +2,15 @@ package com.sesac7.hellopet.domain.announcement.controller;
 
 import com.sesac7.hellopet.common.utils.CustomUserDetails;
 import com.sesac7.hellopet.domain.announcement.dto.request.AnnouncementCreateRequest;
-import com.sesac7.hellopet.domain.announcement.dto.response.AnnouncementDetailResponse;
-import com.sesac7.hellopet.domain.announcement.dto.response.AnnouncementListResponse;
 import com.sesac7.hellopet.domain.announcement.dto.response.AnnouncementCreateResponse;
+import com.sesac7.hellopet.domain.announcement.dto.response.AnnouncementDetailResponse;
 import com.sesac7.hellopet.domain.announcement.dto.response.AnnouncementListResponse;
 import com.sesac7.hellopet.domain.announcement.service.AnnouncementService;
 import com.sesac7.hellopet.domain.application.dto.request.ApplicationPageRequest;
+import com.sesac7.hellopet.domain.application.dto.response.ApplicationApprovalResponse;
 import com.sesac7.hellopet.domain.application.dto.response.ShelterApplicationsPageResponse;
 import com.sesac7.hellopet.domain.application.service.ApplicationService;
 import jakarta.validation.Valid;
-import jakarta.persistence.Id;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,6 +48,7 @@ public class AnnouncementController {
                 announcementCreateRequest, customUserDetails));
 
     }
+
     /**
      * 전체 입양 게시글 리스트 조회
      */
@@ -58,6 +59,13 @@ public class AnnouncementController {
         return ResponseEntity.ok(announcements);
     }
 
+    /**
+     * 공고별 신청 내역 조회
+     *
+     * @param id      공고 ID
+     * @param request 페이지 정보를 담은 요청 DTO
+     * @return 공고 ID에 해당는 공고에 접수된 신청서 리스트 및 페이지 정보
+     */
     @GetMapping("/{id}/applications")
     public ResponseEntity<ShelterApplicationsPageResponse> getApplications(
             @PathVariable Long id,
@@ -65,6 +73,24 @@ public class AnnouncementController {
 
         ShelterApplicationsPageResponse response = applicationService.getShelterApplications(id, request);
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 입양 신청서 상태를 승인 및 거절로 처리하고 공고를 완료 처리
+     *
+     * @param announcementId 공고 ID
+     * @param applicationId  승인할 신청서 ID
+     * @return 상태 변경 결과 응답
+     */
+    @PutMapping("/{announcementId}/applications/{applicationId}")
+    public ResponseEntity<ApplicationApprovalResponse> updateApplicationStatus(
+            @PathVariable Long announcementId,
+            @PathVariable Long applicationId) {
+
+        ApplicationApprovalResponse response = applicationService.processApplicationApproval(
+                announcementId,
+                applicationId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
     /***

--- a/src/main/java/com/sesac7/hellopet/domain/announcement/entity/Announcement.java
+++ b/src/main/java/com/sesac7/hellopet/domain/announcement/entity/Announcement.java
@@ -40,9 +40,11 @@ public class Announcement {
     @OneToOne
     private Pet pet;
 
-    
     private LocalDateTime createAt;
     private LocalDateTime updateAt;
 
-
+    public void changeStatus(AnnouncementStatus newStatus) {
+        this.status = newStatus;
+        this.updateAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/announcement/service/AnnouncementService.java
@@ -124,4 +124,8 @@ public class AnnouncementService {
                                          .build();                                  // DTO 객체 생성 및 반환
     }
 
+    public void completeAnnouncement(Long id) {
+        Announcement announcement = findById(id);
+        announcement.changeStatus(AnnouncementStatus.COMPLETED);
+    }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/application/dto/response/ApplicationApprovalResponse.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/dto/response/ApplicationApprovalResponse.java
@@ -1,6 +1,5 @@
 package com.sesac7.hellopet.domain.application.dto.response;
 
-import com.sesac7.hellopet.domain.application.entity.ApplicationStatus;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,15 +9,13 @@ import lombok.Getter;
 public class ApplicationApprovalResponse {
     private Long announcementId;
     private Long applicationId;
-    private ApplicationStatus status;
     private LocalDateTime processedAt;
     private String message;
 
-    public static ApplicationApprovalResponse of(Long announcementId, Long applicationId, ApplicationStatus status) {
+    public static ApplicationApprovalResponse of(Long announcementId, Long applicationId) {
         return ApplicationApprovalResponse.builder()
                                           .announcementId(announcementId)
                                           .applicationId(applicationId)
-                                          .status(status)
                                           .processedAt(LocalDateTime.now())
                                           .message("승인이 완료되었습니다.")
                                           .build();

--- a/src/main/java/com/sesac7/hellopet/domain/application/dto/response/ApplicationApprovalResponse.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/dto/response/ApplicationApprovalResponse.java
@@ -1,0 +1,26 @@
+package com.sesac7.hellopet.domain.application.dto.response;
+
+import com.sesac7.hellopet.domain.application.entity.ApplicationStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApplicationApprovalResponse {
+    private Long announcementId;
+    private Long applicationId;
+    private ApplicationStatus status;
+    private LocalDateTime processedAt;
+    private String message;
+
+    public static ApplicationApprovalResponse of(Long announcementId, Long applicationId, ApplicationStatus status) {
+        return ApplicationApprovalResponse.builder()
+                                          .announcementId(announcementId)
+                                          .applicationId(applicationId)
+                                          .status(status)
+                                          .processedAt(LocalDateTime.now())
+                                          .message("승인이 완료되었습니다.")
+                                          .build();
+    }
+}

--- a/src/main/java/com/sesac7/hellopet/domain/application/entity/Application.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/entity/Application.java
@@ -95,7 +95,7 @@ public class Application {
         this.agreementInfo = agreementInfo;
     }
 
-    public void completeProcessing(ApplicationStatus newStatus) {
+    public void changeStatus(ApplicationStatus newStatus) {
         this.status = newStatus;
         this.processedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/sesac7/hellopet/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/repository/ApplicationRepository.java
@@ -25,4 +25,12 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
                 ORDER BY app.submittedAt DESC
             """)
     List<Application> findApplicationsWithUserDetailByAnnouncementId(@Param("announcementId") Long announcementId);
+
+    @Query("""
+                SELECT app FROM Application app
+                WHERE app.announcement.id = :announcementId
+                AND app.id != :applicationId
+            """)
+    List<Application> findByAnnouncementIdAndExcludeApplicationId(@Param("announcementId") Long announcementId,
+                                                                  @Param("applicationId") Long applicationId);
 }


### PR DESCRIPTION
- 보호소 관리자가 자신의 공고의 신청 내역 화면에서 “승인” 버튼을 클릭
- 승인 버튼 클릭 시:
    - 해당 신청서 ID에 해당하는 신청서의 상태를 승인으로 변경
    - 같은 공고에 속한 나머지 입양 신청서들의 상태를 거절로 변경
    - 해당 공고의 상태를 IN_PROGRESS →  COMPLETED로 변경
- 위 로직은 트랜잭션으로 처리  → 원자성 보장