### PR TITLE
공고 ID 미검증으로 인한 승인/거절 처리 오류 [#back-46]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/repository/ApplicationRepository.java
@@ -2,6 +2,7 @@ package com.sesac7.hellopet.domain.application.repository;
 
 import com.sesac7.hellopet.domain.application.entity.Application;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -33,4 +34,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             """)
     List<Application> findByAnnouncementIdAndExcludeApplicationId(@Param("announcementId") Long announcementId,
                                                                   @Param("applicationId") Long applicationId);
+
+    Optional<Application> findByIdAndAnnouncementId(Long applicationId, Long announcementId);
 }

--- a/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
@@ -117,10 +117,9 @@ public class ApplicationService {
     }
 
     private void approveAndRejectOtherApplications(Long announcementId, Long applicationId) {
-        Application application = applicationRepository.findById(applicationId)
+        Application application = applicationRepository.findByIdAndAnnouncementId(applicationId, announcementId)
                                                        .orElseThrow(() -> new EntityNotFoundException(
-                                                               "해당 입양 신청서를 찾을 수 없습니다. id=" + applicationId)
-                                                       );
+                                                               "해당 공고에 일치하는 신청서를 찾을 수 없습니다."));
 
         application.changeStatus(ApplicationStatus.APPROVED);
 


### PR DESCRIPTION
- **문제상황**
    - 신청서 승인 처리 시 `applicationId`만으로 신청서를 조회하고, 해당 신청서가 전달받은 `announcementId`에 속하는지 검증하지 않음
    - 그로 인해:
        - 다른 공고의 신청서가 잘못 승인될 수 있음.
        - 존재하지 않거나 일치하지 않는 신청서 ID를 전달하면 해당 공고의 모든 신청서가 거절 처리됨

- **해결방법**
    - `applicationId`와 `announcementId`를 함께 조회하는 쿼리 메서드(`findByIdAndAnnouncementId`)를 추가
    - 서비스 코드에서 해당 메서드를 사용해 정합성을 보장