### PR TITLE
acceessToken 만료시 refreshToken으로 accessToken 재발급[#back-17]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/common/utils/JwtUtil.java
+++ b/src/main/java/com/sesac7/hellopet/common/utils/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.sesac7.hellopet.common.utils;
 
+import com.sesac7.hellopet.domain.user.entity.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -35,16 +36,21 @@ public class JwtUtil {
             long maxAgeMinutes
     ) {
         return ResponseCookie.from(name, value)
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .sameSite("Strict")
-                .maxAge(Duration.ofMinutes(maxAgeMinutes))
-                .build();
+                             .httpOnly(true)
+                             .secure(true)
+                             .path("/")
+                             .sameSite("Strict")
+                             .maxAge(Duration.ofMinutes(maxAgeMinutes))
+                             .build();
     }
 
     public ResponseCookie generateAccessCookie(CustomUserDetails userDetails) {
         String token = doGenerateToken(userDetails, expiration);
+        return buildCookie("accessToken", token, expiration);
+    }
+
+    public ResponseCookie generateAccessCookie(User user) {
+        String token = doGenerateToken(user, expiration);
         return buildCookie("accessToken", token, expiration);
     }
 
@@ -61,17 +67,28 @@ public class JwtUtil {
         return buildCookie("refreshToken", "", 0);
     }
 
-
     private String doGenerateToken(CustomUserDetails userDetails, Long expiration) {
         Claims claims = Jwts.claims();
         claims.setSubject(userDetails.getUsername());
         return Jwts.builder()
-                .setClaims(claims)
-                .claim("role", userDetails.getRole().name())
-                .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + expiration * 60 * 1000))
-                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
-                .compact();
+                   .setClaims(claims)
+                   .claim("role", userDetails.getRole().name())
+                   .setIssuedAt(new Date(System.currentTimeMillis()))
+                   .setExpiration(new Date(System.currentTimeMillis() + expiration * 60 * 1000))
+                   .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                   .compact();
+    }
+
+    private String doGenerateToken(User user, Long expiration) {
+        Claims claims = Jwts.claims();
+        claims.setSubject(user.getEmail());
+        return Jwts.builder()
+                   .setClaims(claims)
+                   .claim("role", user.getRole().name())
+                   .setIssuedAt(new Date(System.currentTimeMillis()))
+                   .setExpiration(new Date(System.currentTimeMillis() + expiration * 60 * 1000))
+                   .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                   .compact();
     }
 
     public String getEmailFromToken(String token) {

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authController/AuthController.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authController/AuthController.java
@@ -26,18 +26,23 @@ public class AuthController {
         AuthResult result = authService.userLogin(request);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .header(HttpHeaders.SET_COOKIE, result.getAccessCookie().toString())
-                .header(HttpHeaders.SET_COOKIE, result.getRefreshCookie().toString())
-                .body(result.getLoginResponse());
+                             .header(HttpHeaders.SET_COOKIE, result.getAccessCookie().toString())
+                             .header(HttpHeaders.SET_COOKIE, result.getRefreshCookie().toString())
+                             .body(result.getLoginResponse());
     }
 
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout() {
         AuthResult result = authService.userLogout();
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .header(HttpHeaders.SET_COOKIE, result.getAccessCookie().toString())
-                .header(HttpHeaders.SET_COOKIE, result.getRefreshCookie().toString())
-                .build();
+                             .header(HttpHeaders.SET_COOKIE, result.getAccessCookie().toString())
+                             .header(HttpHeaders.SET_COOKIE, result.getRefreshCookie().toString())
+                             .build();
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> reissue() {
+        return null;
     }
 
     @PostMapping("/check-password")

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authController/AuthController.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authController/AuthController.java
@@ -7,13 +7,18 @@ import com.sesac7.hellopet.domain.auth.dto.request.LoginRequest;
 import com.sesac7.hellopet.domain.auth.dto.response.AuthResult;
 import com.sesac7.hellopet.domain.auth.dto.response.CheckPasswordResponse;
 import com.sesac7.hellopet.domain.auth.dto.response.LoginResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
@@ -41,8 +46,10 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<Void> reissue() {
-        return null;
+    public ResponseEntity<Void> reissue(HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.OK)
+                             .header(HttpHeaders.SET_COOKIE, authService.reissueAccess(request).toString())
+                             .build();
     }
 
     @PostMapping("/check-password")

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -11,7 +11,11 @@ import com.sesac7.hellopet.domain.auth.repository.RefreshTokenRepository;
 import com.sesac7.hellopet.domain.user.entity.User;
 import com.sesac7.hellopet.domain.user.service.UserFinder;
 import com.sesac7.hellopet.domain.user.service.UserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.Arrays;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -67,7 +71,7 @@ public class AuthService {
         User foundUser = userFinder.findLoggedInUserByUsername(userDetails.getUsername());
 
         refreshFinder.deleteRefreshByUser(foundUser);
-        
+
         SecurityContextHolder.clearContext();
         return new AuthResult(jwtUtil.deleteAccessCookie(), jwtUtil.deleteRefreshCookie(), null);
     }
@@ -80,4 +84,10 @@ public class AuthService {
         return new CheckPasswordResponse("확인 되었습니다.", true);
     }
 
+    public void reissueAccess(HttpServletRequest request) {
+        String token = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
+                             .filter(c -> "refreshToken".equals(c.getName()))
+                             .map(Cookie::getValue)
+                             .findFirst().orElse(null);
+    }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -93,6 +93,11 @@ public class AuthService {
         if (token == null) {
             throw new UnauthorizedException();
         }
+        
+        if (jwtUtil.isTokenExpired(token)) {
+            throw new UnauthorizedException();
+        }
+
         User foundUser = refreshFinder.getUserByToken(token);
         return jwtUtil.generateAccessCookie(foundUser);
     }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -94,5 +94,6 @@ public class AuthService {
             throw new UnauthorizedException();
         }
         User foundUser = refreshFinder.getUserByToken(token);
+        ResponseCookie accessCookie = jwtUtil.generateAccessCookie(foundUser);
     }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -30,6 +30,8 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     private final UserService userService;
+    private final RefreshFinder refreshFinder;
+
     private final UserFinder userFinder;
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
@@ -50,8 +52,10 @@ public class AuthService {
         ResponseCookie refreshCookie = jwtUtil.generateRefreshCookie(userDetails);
         User foundUser = userService.getUserByEmailFromDatabase(userDetails.getUsername());
 
-        refreshTokenRepository.save(
-                new RefreshToken(null, refreshCookie.getValue(), foundUser));
+        if (!refreshFinder.existRefresh(refreshCookie.getValue())) {
+            refreshTokenRepository.save(
+                    new RefreshToken(null, refreshCookie.getValue(), foundUser));
+        }
 
         return new AuthResult(accessCookie, refreshCookie, userService.userLogin(userDetails.getUsername()));
     }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -90,12 +90,13 @@ public class AuthService {
                              .filter(c -> "refreshToken".equals(c.getName()))
                              .map(Cookie::getValue)
                              .findFirst().orElse(null);
+
         if (token == null) {
-            throw new UnauthorizedException();
+            throw new UnauthorizedException(jwtUtil.deleteAccessCookie(), jwtUtil.deleteRefreshCookie());
         }
-        
+
         if (jwtUtil.isTokenExpired(token)) {
-            throw new UnauthorizedException();
+            throw new UnauthorizedException(jwtUtil.deleteAccessCookie(), jwtUtil.deleteRefreshCookie());
         }
 
         User foundUser = refreshFinder.getUserByToken(token);

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -93,5 +93,6 @@ public class AuthService {
         if (token == null) {
             throw new UnauthorizedException();
         }
+        User foundUser = refreshFinder.getUserByToken(token);
     }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -6,13 +6,11 @@ import com.sesac7.hellopet.domain.auth.dto.request.CheckPasswordRequest;
 import com.sesac7.hellopet.domain.auth.dto.request.LoginRequest;
 import com.sesac7.hellopet.domain.auth.dto.response.AuthResult;
 import com.sesac7.hellopet.domain.auth.dto.response.CheckPasswordResponse;
-import com.sesac7.hellopet.domain.auth.dto.response.LoginResponse;
 import com.sesac7.hellopet.domain.user.entity.User;
 import com.sesac7.hellopet.domain.user.service.UserFinder;
 import com.sesac7.hellopet.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -43,12 +41,13 @@ public class AuthService {
         SecurityContextHolder.getContext().setAuthentication(authentication);
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 
-        return new AuthResult(jwtUtil.generateAccessCookie(userDetails), jwtUtil.generateRefreshCookie(userDetails), userService.userLogin(userDetails.getUsername()));
+        return new AuthResult(jwtUtil.generateAccessCookie(userDetails), jwtUtil.generateRefreshCookie(userDetails),
+                userService.userLogin(userDetails.getUsername()));
     }
 
     public AuthResult userLogout() {
         SecurityContextHolder.clearContext();
-        return new AuthResult(jwtUtil. deleteAccessCookie(), jwtUtil.deleteRefreshCookie(), null);
+        return new AuthResult(jwtUtil.deleteAccessCookie(), jwtUtil.deleteRefreshCookie(), null);
     }
 
     public CheckPasswordResponse checkPassword(@Valid CheckPasswordRequest request, CustomUserDetails userDetails) {

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -85,7 +85,7 @@ public class AuthService {
         return new CheckPasswordResponse("확인 되었습니다.", true);
     }
 
-    public void reissueAccess(HttpServletRequest request) {
+    public ResponseCookie reissueAccess(HttpServletRequest request) {
         String token = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
                              .filter(c -> "refreshToken".equals(c.getName()))
                              .map(Cookie::getValue)
@@ -94,6 +94,6 @@ public class AuthService {
             throw new UnauthorizedException();
         }
         User foundUser = refreshFinder.getUserByToken(token);
-        ResponseCookie accessCookie = jwtUtil.generateAccessCookie(foundUser);
+        return jwtUtil.generateAccessCookie(foundUser);
     }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -61,6 +61,13 @@ public class AuthService {
     }
 
     public AuthResult userLogout() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        User foundUser = userFinder.findLoggedInUserByUsername(userDetails.getUsername());
+
+        refreshFinder.deleteRefreshByUser(foundUser);
+        
         SecurityContextHolder.clearContext();
         return new AuthResult(jwtUtil.deleteAccessCookie(), jwtUtil.deleteRefreshCookie(), null);
     }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/AuthService.java
@@ -11,6 +11,7 @@ import com.sesac7.hellopet.domain.auth.repository.RefreshTokenRepository;
 import com.sesac7.hellopet.domain.user.entity.User;
 import com.sesac7.hellopet.domain.user.service.UserFinder;
 import com.sesac7.hellopet.domain.user.service.UserService;
+import com.sesac7.hellopet.global.exception.custom.UnauthorizedException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -89,5 +90,8 @@ public class AuthService {
                              .filter(c -> "refreshToken".equals(c.getName()))
                              .map(Cookie::getValue)
                              .findFirst().orElse(null);
+        if (token == null) {
+            throw new UnauthorizedException();
+        }
     }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinder.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinder.java
@@ -1,5 +1,9 @@
 package com.sesac7.hellopet.domain.auth.authService;
 
+import com.sesac7.hellopet.domain.user.entity.User;
+
 public interface RefreshFinder {
     Boolean existRefresh(String refreshToken);
+
+    void deleteRefreshByUser(User foundUser);
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinder.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinder.java
@@ -1,0 +1,5 @@
+package com.sesac7.hellopet.domain.auth.authService;
+
+public interface RefreshFinder {
+    Boolean existRefresh(String refreshToken);
+}

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinder.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinder.java
@@ -6,4 +6,6 @@ public interface RefreshFinder {
     Boolean existRefresh(String refreshToken);
 
     void deleteRefreshByUser(User foundUser);
+
+    User getUserByToken(String token);
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinderImpl.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinderImpl.java
@@ -1,0 +1,17 @@
+package com.sesac7.hellopet.domain.auth.authService;
+
+import com.sesac7.hellopet.domain.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RefreshFinderImpl implements RefreshFinder {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public Boolean existRefresh(String refreshToken) {
+        return refreshTokenRepository.existsRefreshTokenByToken(refreshToken);
+    }
+}

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinderImpl.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinderImpl.java
@@ -1,5 +1,6 @@
 package com.sesac7.hellopet.domain.auth.authService;
 
+import com.sesac7.hellopet.domain.auth.entity.RefreshToken;
 import com.sesac7.hellopet.domain.auth.repository.RefreshTokenRepository;
 import com.sesac7.hellopet.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -19,5 +20,11 @@ public class RefreshFinderImpl implements RefreshFinder {
     @Override
     public void deleteRefreshByUser(User foundUser) {
         refreshTokenRepository.deleteRefreshTokenByUser(foundUser);
+    }
+
+    @Override
+    public User getUserByToken(String token) {
+        RefreshToken refreshToken = refreshTokenRepository.findRefreshTokenByToken(token);
+        return refreshToken.getUser();
     }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinderImpl.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/authService/RefreshFinderImpl.java
@@ -1,6 +1,7 @@
 package com.sesac7.hellopet.domain.auth.authService;
 
 import com.sesac7.hellopet.domain.auth.repository.RefreshTokenRepository;
+import com.sesac7.hellopet.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,5 +14,10 @@ public class RefreshFinderImpl implements RefreshFinder {
 
     public Boolean existRefresh(String refreshToken) {
         return refreshTokenRepository.existsRefreshTokenByToken(refreshToken);
+    }
+
+    @Override
+    public void deleteRefreshByUser(User foundUser) {
+        refreshTokenRepository.deleteRefreshTokenByUser(foundUser);
     }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/entity/RefreshToken.java
@@ -25,7 +25,7 @@ public class RefreshToken {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private String tokenHash;
+    private String token;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", unique = true)

--- a/src/main/java/com/sesac7/hellopet/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/entity/RefreshToken.java
@@ -1,5 +1,6 @@
-package com.sesac7.hellopet.domain.user.entity;
+package com.sesac7.hellopet.domain.auth.entity;
 
+import com.sesac7.hellopet.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,35 +13,21 @@ import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
-@Table(name = "user_details")
 @Getter
+@Table(name = "refresh_tokens")
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserDetail {
+public class RefreshToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter
-    private String nickname;
-
-    @Column(nullable = false)
-    private String username;
-
-    @Setter
-    private String userProfileUrl;
-
-    @Setter
-    @Column(nullable = false)
-    private String address;
-
-    @Column(nullable = false)
-    private String phoneNumber;
+    @Column(nullable = false, unique = true)
+    private String tokenHash;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", unique = true)
     private User user;
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.sesac7.hellopet.domain.auth.repository;
+
+import com.sesac7.hellopet.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/sesac7/hellopet/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/repository/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Boolean existsRefreshTokenByToken(String refreshToken);
 
     void deleteRefreshTokenByUser(User foundUser);
+
+    RefreshToken findRefreshTokenByToken(String token);
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/repository/RefreshTokenRepository.java
@@ -1,10 +1,13 @@
 package com.sesac7.hellopet.domain.auth.repository;
 
 import com.sesac7.hellopet.domain.auth.entity.RefreshToken;
+import com.sesac7.hellopet.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Boolean existsRefreshTokenByToken(String refreshToken);
+
+    void deleteRefreshTokenByUser(User foundUser);
 }

--- a/src/main/java/com/sesac7/hellopet/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sesac7/hellopet/domain/auth/repository/RefreshTokenRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Boolean existsRefreshTokenByToken(String refreshToken);
 }

--- a/src/main/java/com/sesac7/hellopet/domain/user/service/UserService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/user/service/UserService.java
@@ -184,7 +184,6 @@ public class UserService {
         SecurityContextHolder.clearContext();
 
         ResponseCookie deleteAccess = jwtUtil.deleteAccessCookie();
-
         ResponseCookie deleteRefresh = jwtUtil.deleteRefreshCookie();
 
         return new ArrayList<>(List.of(deleteAccess, deleteRefresh));
@@ -200,13 +199,18 @@ public class UserService {
     }
 
     public void deactivateUser(Long userId) {
-        User foundUser = userRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("잘못된 USER ID 입니다."));
-        if(!foundUser.getActivation()) {
+        User foundUser = userRepository.findById(userId)
+                                       .orElseThrow(() -> new UsernameNotFoundException("잘못된 USER ID 입니다."));
+        if (!foundUser.getActivation()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 비활성화 된 유저입니다.");
         }
-        if(foundUser.getRole().equals(UserRole.ADMIN)) {
+        if (foundUser.getRole().equals(UserRole.ADMIN)) {
             throw new AuthorizationDeniedException("권한이 없습니다.");
         }
         foundUser.setActivation(false);
+    }
+
+    public User getUserByEmailFromDatabase(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("잘못된 유저 입니다."));
     }
 }

--- a/src/main/java/com/sesac7/hellopet/global/config/SecurityConfig.java
+++ b/src/main/java/com/sesac7/hellopet/global/config/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers("/auth/**").permitAll()
+                        .anyRequest().authenticated()
                 );
         return http.build();
     }

--- a/src/main/java/com/sesac7/hellopet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sesac7/hellopet/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.sesac7.hellopet.global.exception;
 
+import com.sesac7.hellopet.global.exception.custom.UnauthorizedException;
 import com.sesac7.hellopet.global.exception.custom.WithdrawUserException;
 import com.sesac7.hellopet.global.exception.dto.response.ErrorMessage;
 import java.util.HashMap;
@@ -17,7 +18,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ErrorMessage> responseStatusExceptionHandler(ResponseStatusException e) {
         return ResponseEntity.status(e.getStatusCode())
-                .body(new ErrorMessage(String.valueOf(e.getStatusCode().value()), e.getReason()));
+                             .body(new ErrorMessage(String.valueOf(e.getStatusCode().value()), e.getReason()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -38,6 +39,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(WithdrawUserException.class)
     public ResponseEntity<ErrorMessage> responseInactivationUserExceptionHandler(WithdrawUserException e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorMessage(HttpStatus.FORBIDDEN.toString(),
+                e.getMessage()));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorMessage> responseUnauthorizedUserExceptionHandler(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorMessage(HttpStatus.UNAUTHORIZED.toString(),
                 e.getMessage()));
     }
 }

--- a/src/main/java/com/sesac7/hellopet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sesac7/hellopet/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.sesac7.hellopet.global.exception.custom.WithdrawUserException;
 import com.sesac7.hellopet.global.exception.dto.response.ErrorMessage;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -44,7 +45,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ErrorMessage> responseUnauthorizedUserExceptionHandler(UnauthorizedException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorMessage(HttpStatus.UNAUTHORIZED.toString(),
-                e.getMessage()));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .header(HttpHeaders.SET_COOKIE, e.getAccessCookie().toString())
+                             .header(HttpHeaders.SET_COOKIE, e.getRefreshCookie().toString())
+                             .body(new ErrorMessage(HttpStatus.BAD_REQUEST.toString(), e.getMessage()));
     }
 }

--- a/src/main/java/com/sesac7/hellopet/global/exception/custom/UnauthorizedException.java
+++ b/src/main/java/com/sesac7/hellopet/global/exception/custom/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.sesac7.hellopet.global.exception.custom;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException() {
+        super("Refresh 토큰이 없습니다.");
+    }
+}

--- a/src/main/java/com/sesac7/hellopet/global/exception/custom/UnauthorizedException.java
+++ b/src/main/java/com/sesac7/hellopet/global/exception/custom/UnauthorizedException.java
@@ -1,7 +1,17 @@
 package com.sesac7.hellopet.global.exception.custom;
 
+import lombok.Getter;
+import org.springframework.http.ResponseCookie;
+
+@Getter
 public class UnauthorizedException extends RuntimeException {
-    public UnauthorizedException() {
+
+    private final ResponseCookie accessCookie;
+    private final ResponseCookie refreshCookie;
+
+    public UnauthorizedException(ResponseCookie accessCookie, ResponseCookie refreshCookie) {
         super("Refresh 토큰이 없습니다.");
+        this.accessCookie = accessCookie;
+        this.refreshCookie = refreshCookie;
     }
 }

--- a/src/main/java/com/sesac7/hellopet/global/filter/JwtFilter.java
+++ b/src/main/java/com/sesac7/hellopet/global/filter/JwtFilter.java
@@ -33,17 +33,12 @@ public class JwtFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String token = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
-                .filter(c -> "accessToken".equals(c.getName()))
-                .map(Cookie::getValue)
-                .findFirst().orElse(null);
+                             .filter(c -> "accessToken".equals(c.getName()))
+                             .map(Cookie::getValue)
+                             .findFirst().orElse(null);
 
-        if (token == null) {
+        if (token == null || jwtUtil.isTokenExpired(token)) {
             filterChain.doFilter(request, response);
-            return;
-        }
-
-        if (jwtUtil.isTokenExpired(token)) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 


### PR DESCRIPTION
- 만료된 `accessToken` 요청 시 **POST `/refresh`** 로 새 `accessToken` + (로테이션된) `refreshToken` 쿠키를 발급한다.
- `refreshToken`이 없거나 만료·위조·재사용(revoked) 이면 **400 Bad request** 와 함께 삭제 쿠키(`Max-Age=0`)를 반환한다.
- `accessToken`·`refreshToken` 쿠키는 만료·로그아웃 시 반드시 무효화 쿠키를 내려준다.
- `RefreshToken` 엔티티(토큰 해시 저장)와 리포지터리를 사용해 로그인 시 저장, 재발급 시 `revoked=true` 후 새 행 INSERT, 로그아웃 시 삭제/무효화를 수행한다.
- 커스텀 필터는 `accessToken` 검증에 실패하면 `/refresh` 외 URL에서 Spring Security `AuthenticationEntryPoint`를 통해 401을 트리거한다.
- 통합 테스트는 정상 재발급, 만료/재사용 refresh, 로그아웃 후 접근 등 핵심 시나리오를 모두 통과하고, 재발급 과정의 DB 쿼리는 3회 이하로 제한된다.