### PR TITLE
공고별 신청 내역 API 응답 구조 리팩토링 [#back-69]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/application/dto/response/ShelterApplicationResponse.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/dto/response/ShelterApplicationResponse.java
@@ -1,26 +1,22 @@
 package com.sesac7.hellopet.domain.application.dto.response;
 
-import com.sesac7.hellopet.domain.announcement.entity.Announcement;
 import com.sesac7.hellopet.domain.application.entity.Application;
 import com.sesac7.hellopet.domain.user.entity.UserDetail;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class ShelterApplicationResponse {
-    private Long announcementId;
-    private LocalDateTime announcementCreatedAt;
+    private Long applicationId;
     private String userName;
     private String userPhoneNumber;
     private String userEmail;
 
-    public static ShelterApplicationResponse of(Announcement announcement, Application application) {
+    public static ShelterApplicationResponse from(Application application) {
         UserDetail userDetail = application.getApplicant().getUserDetail();
         return ShelterApplicationResponse.builder()
-                                         .announcementId(announcement.getId())
-                                         .announcementCreatedAt(announcement.getCreatedAt())
+                                         .applicationId(application.getId())
                                          .userName(userDetail.getUsername())
                                          .userPhoneNumber(userDetail.getPhoneNumber())
                                          .userEmail(application.getApplicant().getEmail())

--- a/src/main/java/com/sesac7/hellopet/domain/application/dto/response/ShelterApplicationsPageResponse.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/dto/response/ShelterApplicationsPageResponse.java
@@ -1,5 +1,7 @@
 package com.sesac7.hellopet.domain.application.dto.response;
 
+import com.sesac7.hellopet.domain.announcement.entity.Announcement;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,12 +14,14 @@ public class ShelterApplicationsPageResponse {
     private int size;
     private int totalPages;
     private long totalElements;
+    private Long announcementId;
+    private LocalDateTime announcementCreatedAt;
     private List<ShelterApplicationResponse> applications;
 
-    public static ShelterApplicationsPageResponse of(
-            Pageable pageable
+    public static ShelterApplicationsPageResponse of(Pageable pageable
             , List<ShelterApplicationResponse> content
-            , long totalElements) {
+            , long totalElements
+            , Announcement announcement) {
 
         int totalPages = (int) Math.ceil((double) totalElements / pageable.getPageSize());
 
@@ -26,6 +30,8 @@ public class ShelterApplicationsPageResponse {
                                               .size(pageable.getPageSize())
                                               .totalElements(totalElements)
                                               .totalPages(totalPages)
+                                              .announcementId(announcement.getId())
+                                              .announcementCreatedAt(announcement.getCreatedAt())
                                               .applications(content)
                                               .build();
     }

--- a/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
@@ -74,10 +74,10 @@ public class ApplicationService {
         List<ShelterApplicationResponse> content = applications
                 .subList(start, end)
                 .stream()
-                .map(application -> ShelterApplicationResponse.of(announcement, application))
+                .map(application -> ShelterApplicationResponse.from(application))
                 .toList();
 
-        return ShelterApplicationsPageResponse.of(pageable, content, applications.size());
+        return ShelterApplicationsPageResponse.of(pageable, content, applications.size(), announcement);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
- 공고별 신청 내역 API 응답에서 신청서 ID(applicationId) 를 각 신청 항목에 추가
- 응답 최상위에 공고 ID(announcementId) 와 공고 생성일(announcementCreatedAt) 을 포함