### PR TITLE
보호소가 자신이 올린 공고에 대해서만 승인할 수 있는 기능 추가 [#back-71]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
@@ -87,11 +87,12 @@ public class AnnouncementController {
     @PutMapping("/{announcementId}/applications/{applicationId}")
     public ResponseEntity<ApplicationApprovalResponse> updateApplicationStatus(
             @PathVariable Long announcementId,
-            @PathVariable Long applicationId) {
+            @PathVariable Long applicationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         ApplicationApprovalResponse response = applicationService.processApplicationApproval(
-                announcementId,
-                applicationId);
+                announcementId, applicationId, userDetails);
+
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/com/sesac7/hellopet/domain/application/entity/Application.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/entity/Application.java
@@ -8,6 +8,7 @@ import com.sesac7.hellopet.domain.application.entity.info.family.FamilyInfo;
 import com.sesac7.hellopet.domain.application.entity.info.financial.FinancialInfo;
 import com.sesac7.hellopet.domain.application.entity.info.housing.HousingInfo;
 import com.sesac7.hellopet.domain.application.entity.info.plan.FuturePlanInfo;
+import com.sesac7.hellopet.domain.application.validation.AlreadyProcessedApplicationException;
 import com.sesac7.hellopet.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -95,8 +96,18 @@ public class Application {
         this.agreementInfo = agreementInfo;
     }
 
-    public void changeStatus(ApplicationStatus newStatus) {
-        this.status = newStatus;
+    public void approve() {
+        if (this.status != ApplicationStatus.PENDING) {
+            throw new AlreadyProcessedApplicationException();
+        }
+        this.status = ApplicationStatus.APPROVED;
         this.processedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        if (this.status == ApplicationStatus.PENDING) {
+            this.status = ApplicationStatus.REJECTED;
+            this.processedAt = LocalDateTime.now();
+        }
     }
 }

--- a/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
@@ -16,6 +16,7 @@ import com.sesac7.hellopet.domain.application.entity.Application;
 import com.sesac7.hellopet.domain.application.entity.ApplicationStatus;
 import com.sesac7.hellopet.domain.application.repository.ApplicationRepository;
 import com.sesac7.hellopet.domain.application.validation.AlreadyProcessedApplicationException;
+import com.sesac7.hellopet.domain.application.validation.AnnouncementApprovalPermissionException;
 import com.sesac7.hellopet.domain.application.validation.DuplicateApplicationException;
 import com.sesac7.hellopet.domain.user.entity.User;
 import com.sesac7.hellopet.domain.user.entity.UserRole;
@@ -130,7 +131,7 @@ public class ApplicationService {
         User user = userFinder.findLoggedInUserByUsername(userDetails.getUsername());
         Announcement announcement = announcementService.findById(announcementId);
         if (!announcement.getShelter().getId().equals(user.getId()) || user.getRole() != UserRole.SHELTER) {
-            throw new AccessDeniedException("해당 입양 공고에 대한 승인 권한이 없습니다.");
+            throw new AnnouncementApprovalPermissionException();
         }
 
         approveAndRejectOtherApplications(announcementId, applicationId);

--- a/src/main/java/com/sesac7/hellopet/domain/application/validation/AnnouncementApprovalPermissionException.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/validation/AnnouncementApprovalPermissionException.java
@@ -1,0 +1,7 @@
+package com.sesac7.hellopet.domain.application.validation;
+
+public class AnnouncementApprovalPermissionException extends RuntimeException {
+    public AnnouncementApprovalPermissionException() {
+        super("해당 입양 공고에 대한 승인 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/sesac7/hellopet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sesac7/hellopet/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.sesac7.hellopet.global.exception;
 
 import com.sesac7.hellopet.domain.application.validation.AlreadyProcessedApplicationException;
+import com.sesac7.hellopet.domain.application.validation.AnnouncementApprovalPermissionException;
 import com.sesac7.hellopet.domain.application.validation.DuplicateApplicationException;
 import com.sesac7.hellopet.global.exception.custom.UnauthorizedException;
 import com.sesac7.hellopet.global.exception.custom.WithdrawUserException;
@@ -80,6 +81,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> responseAlreadyProcessedApplicationExceptionHandler(
             AlreadyProcessedApplicationException e) {
         return generateExceptionResponse(e, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AnnouncementApprovalPermissionException.class)
+    public ResponseEntity<ExceptionResponse> responseAnnouncementApprovalPermissionExceptionHandler(
+            AnnouncementApprovalPermissionException e) {
+        return generateExceptionResponse(e, HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(EntityNotFoundException.class)


### PR DESCRIPTION
- 컨트롤러에서 현재 로그인한 유저 정보를 주입받음
- 승인 시 공고 작성자 ID와 현재 로그인 유저 ID를 비교함
- 두 ID가 다르면 커스텀 예외를 발생시켜 권한 없음을 알림