### PR TITLE
승인된 입양 신청서 삭제 차단 기능 추가 [#back-74]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
@@ -17,6 +17,7 @@ import com.sesac7.hellopet.domain.application.entity.ApplicationStatus;
 import com.sesac7.hellopet.domain.application.repository.ApplicationRepository;
 import com.sesac7.hellopet.domain.application.validation.AlreadyProcessedApplicationException;
 import com.sesac7.hellopet.domain.application.validation.AnnouncementApprovalPermissionException;
+import com.sesac7.hellopet.domain.application.validation.ApplicationAlreadyApprovedException;
 import com.sesac7.hellopet.domain.application.validation.DuplicateApplicationException;
 import com.sesac7.hellopet.domain.user.entity.User;
 import com.sesac7.hellopet.domain.user.entity.UserRole;
@@ -51,6 +52,10 @@ public class ApplicationService {
 
         if (!application.getApplicant().getId().equals(user.getId())) {
             throw new AccessDeniedException("입양 신청서를 삭제할 권한이 없습니다.");
+        }
+
+        if (application.getStatus() == ApplicationStatus.APPROVED) {
+            throw new ApplicationAlreadyApprovedException(application.getId());
         }
 
         applicationRepository.delete(application);

--- a/src/main/java/com/sesac7/hellopet/domain/application/validation/ApplicationAlreadyApprovedException.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/validation/ApplicationAlreadyApprovedException.java
@@ -1,0 +1,7 @@
+package com.sesac7.hellopet.domain.application.validation;
+
+public class ApplicationAlreadyApprovedException extends RuntimeException {
+    public ApplicationAlreadyApprovedException(Long id) {
+        super("신청서(id=" + id + ")는 이미 승인되어 삭제할 수 없습니다.");
+    }
+}

--- a/src/main/java/com/sesac7/hellopet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sesac7/hellopet/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.sesac7.hellopet.global.exception;
 
 import com.sesac7.hellopet.domain.application.validation.AlreadyProcessedApplicationException;
 import com.sesac7.hellopet.domain.application.validation.AnnouncementApprovalPermissionException;
+import com.sesac7.hellopet.domain.application.validation.ApplicationAlreadyApprovedException;
 import com.sesac7.hellopet.domain.application.validation.DuplicateApplicationException;
 import com.sesac7.hellopet.global.exception.custom.UnauthorizedException;
 import com.sesac7.hellopet.global.exception.custom.WithdrawUserException;
@@ -96,6 +97,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> responseAnnouncementApprovalPermissionExceptionHandler(
             AnnouncementApprovalPermissionException e) {
         return generateExceptionResponse(e, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(ApplicationAlreadyApprovedException.class)
+    public ResponseEntity<ExceptionResponse> handleApprovedException(ApplicationAlreadyApprovedException e) {
+        return generateExceptionResponse(e, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(EntityNotFoundException.class)


### PR DESCRIPTION
- 신청서 상태가 승인인 경우 삭제할 수 없음
- 서비스 계층에서 신청서 승인 여부 검사
- 승인된 신청서를 삭제 시도하면 커스텀 예외 발생
- 전역 예외 처리기를 통해 적절한 HTTP 상태 코드와 메시지 반환