### PR TITLE
자신이 등록한 공고에 대한 신청 내역만 조회 가능하도록 기능 구현 [#back-76]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
@@ -80,11 +80,13 @@ public class AnnouncementController {
     }
 
     /**
-     * 입양 신청서 상태를 승인 및 거절로 처리하고 공고를 완료 처리
+     * 보호소가 접수된 신청서 중 하나를 승인하고,
+     * 나머지 신청서는 거절 처리한 후, 공고 상태를 완료로 변경합니다.
      *
-     * @param announcementId 공고 ID
-     * @param applicationId  승인할 신청서 ID
-     * @return 상태 변경 결과 응답
+     * @param announcementId 승인 및 거절 처리할 공고 ID
+     * @param applicationId  승인할 입양 신청서 ID
+     * @param userDetails    인증된 보호소 사용자 정보
+     * @return 처리 결과를 담은 응답 객체
      */
     @PutMapping("/{announcementId}/applications/{applicationId}")
     public ResponseEntity<ApplicationApprovalResponse> updateApplicationStatus(

--- a/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
@@ -64,16 +64,18 @@ public class AnnouncementController {
     /**
      * 공고별 신청 내역 조회
      *
-     * @param id      공고 ID
-     * @param request 페이지 정보를 담은 요청 DTO
-     * @return 공고 ID에 해당는 공고에 접수된 신청서 리스트 및 페이지 정보
+     * @param id          공고 ID
+     * @param request     페이지 정보를 담은 요청 DTO
+     * @param userDetails 로그인한 보호소 정보
+     * @return 공고 ID에 해당하는 공고에 접수된 신청서 리스트 및 페이지 정보
      */
     @GetMapping("/{id}/applications")
     public ResponseEntity<ShelterApplicationsPageResponse> getApplications(
             @PathVariable Long id,
-            @ModelAttribute @Valid ApplicationPageRequest request) {
+            @ModelAttribute @Valid ApplicationPageRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        ShelterApplicationsPageResponse response = applicationService.getShelterApplications(id, request);
+        ShelterApplicationsPageResponse response = applicationService.getShelterApplications(id, request, userDetails);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
@@ -73,10 +73,18 @@ public class ApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public ShelterApplicationsPageResponse getShelterApplications(Long id, ApplicationPageRequest request) {
-        Announcement announcement = announcementService.findById(id);
-        Pageable pageable = request.toPageable();
+    public ShelterApplicationsPageResponse getShelterApplications(Long id,
+                                                                  ApplicationPageRequest request,
+                                                                  CustomUserDetails userDetails) {
 
+        Announcement announcement = announcementService.findById(id);
+        User shelter = userFinder.findLoggedInUserByUsername(userDetails.getUsername());
+
+        if (!announcement.getShelter().getId().equals(shelter.getId())) {
+            throw new AccessDeniedException("해당 공고에 대한 접근 권한이 없습니다.");
+        }
+
+        Pageable pageable = request.toPageable();
         Page<Application> page = applicationRepository.findByAnnouncementId(id, pageable);
 
         List<ShelterApplicationResponse> content = page.stream()


### PR DESCRIPTION
- 로그인한 보호소 사용자는 자신이 등록한 공고에 대해서만 신청서 목록을 조회할 수 있어야 함
- 다른 보호소가 등록한 공고에 접근할 경우 예외 처리