### PR TITLE
입양 신청 상태 일괄 수정 방식 DB 업데이트로 리팩토링 [#back-77]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/repository/ApplicationRepository.java
@@ -2,15 +2,16 @@ package com.sesac7.hellopet.domain.application.repository;
 
 import com.sesac7.hellopet.domain.application.entity.Application;
 import com.sesac7.hellopet.domain.application.entity.ApplicationStatus;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
@@ -20,13 +21,17 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     @EntityGraph(attributePaths = {"applicant", "applicant.userDetail"})
     Page<Application> findByAnnouncementId(Long announcementId, Pageable pageable);
 
+    @Transactional
+    @Modifying(clearAutomatically = true)
     @Query("""
-                SELECT app FROM Application app
-                WHERE app.announcement.id = :announcementId
-                AND app.id != :applicationId
+                UPDATE Application a
+                SET a.status = 'REJECTED'
+                WHERE a.announcement.id = :announcementId
+                AND a.id != :applicationId
+                AND a.status = 'PENDING'
             """)
-    List<Application> findByAnnouncementIdAndExcludeApplicationId(@Param("announcementId") Long announcementId,
-                                                                  @Param("applicationId") Long applicationId);
+    int bulkRejectApplications(@Param("announcementId") Long announcementId,
+                               @Param("applicationId") Long applicationId);
 
     Optional<Application> findByIdAndAnnouncementIdAndStatus(Long applicationId, Long announcementId,
                                                              ApplicationStatus status);

--- a/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
@@ -167,10 +167,6 @@ public class ApplicationService {
                                                        .orElseThrow(() -> new AlreadyProcessedApplicationException());
 
         approvedApp.approve();
-
-        List<Application> rejectedApps = applicationRepository.findByAnnouncementIdAndExcludeApplicationId(
-                announcementId, applicationId);
-
-        rejectedApps.forEach(other -> other.reject());
+        applicationRepository.bulkRejectApplications(announcementId, applicationId);
     }
 }


### PR DESCRIPTION
- 승인되지 않은 신청서들을 JPA 반복문이 아닌 DB 쿼리로 일괄 업데이트할 수 있어야 함
- application.status가 'REJECTED'로 직접 업데이트됨 → 성능 향상