### PR TITLE
공고 상세 조회 시 신청 여부 포함 [#back-80]

### DIFF
--- a/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/sesac7/hellopet/domain/announcement/controller/AnnouncementController.java
@@ -104,8 +104,9 @@ public class AnnouncementController {
      * 입양 리스트 상세 조회
      */
     @GetMapping("/{id}")
-    public ResponseEntity<AnnouncementDetailResponse> getAnnouncementDetail(@PathVariable Long id) {
-        AnnouncementDetailResponse detail = announcementService.getAnnouncementDetail(id);
+    public ResponseEntity<AnnouncementDetailResponse> getAnnouncementDetail(@PathVariable Long id,
+                                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        AnnouncementDetailResponse detail = announcementService.getAnnouncementDetail(id, userDetails);
         return ResponseEntity.ok(detail);
     }
 

--- a/src/main/java/com/sesac7/hellopet/domain/announcement/dto/response/AnnouncementDetailResponse.java
+++ b/src/main/java/com/sesac7/hellopet/domain/announcement/dto/response/AnnouncementDetailResponse.java
@@ -21,4 +21,5 @@ public class AnnouncementDetailResponse {
     private String imageUrl; // 강아지 이미지
     private AnnouncementStatus announcementStatus; // 입양 상태
     private String animalType;
+    private boolean alreadyApplied; // 입양자 신청 여부
 }

--- a/src/main/java/com/sesac7/hellopet/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/repository/ApplicationRepository.java
@@ -37,4 +37,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
                                                              ApplicationStatus status);
 
     Optional<Application> findByApplicantIdAndAnnouncementId(Long userId, Long announcementId);
+
+    boolean existsByAnnouncementIdAndApplicantId(Long announcementId, Long userId);
 }

--- a/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/sesac7/hellopet/domain/application/service/ApplicationService.java
@@ -169,4 +169,8 @@ public class ApplicationService {
         approvedApp.approve();
         applicationRepository.bulkRejectApplications(announcementId, applicationId);
     }
+
+    public boolean existsByAnnouncementIdAndApplicantId(Long announcementId, Long userId) {
+        return applicationRepository.existsByAnnouncementIdAndApplicantId(announcementId, userId);
+    }
 }


### PR DESCRIPTION
- 로그인한 사용자가 해당 공고에 입양 신청했는지 여부를 확인할 수 있음
- 공고 상세 응답에 alreadyApplied: boolean 필드가 포함됨
- 프론트는 해당 값을 기반으로 입양 신청 버튼의 노출 여부를 제어할 수 있음